### PR TITLE
Added Pictograph Box Export

### DIFF
--- a/src/MajorasMaskOnline/Bitmap.ts
+++ b/src/MajorasMaskOnline/Bitmap.ts
@@ -1,0 +1,99 @@
+// TODO: Probably needs a lot of reworking if it's being used for more than just pictographs
+
+export enum BitDepth {
+    BPP_1 = 1,
+    BPP_4 = 4,
+    BPP_8 = 8,
+    BPP_16 = 16,
+    BPP_24 = 24,
+    BPP_32 = 32
+}
+
+export class BMP_Image {
+
+    file: Buffer;
+
+    constructor(width: number, height: number, bitDepth: BitDepth, colorAmt?: number) {
+        let colorTableSize = ((): number => {
+            if (colorAmt) return colorAmt;
+            if (bitDepth <= 8) return Math.pow(2, bitDepth);
+            return 0;
+        })();
+        colorAmt = colorAmt ? colorAmt : 0;
+        let pixelSize = ((): number => {
+            return Math.ceil(bitDepth / 8);
+        })();
+        this.file = Buffer.alloc(
+            14 +                                            // File Header
+            40 +                                            // Image Header
+            colorTableSize * 4 +                            // Color Table
+            Math.ceil(pixelSize * width / 4) * 4 * height   // Pixel Data size
+        );
+        this.file.write("BM", "ascii");
+        this.file.writeInt32LE(54 + colorTableSize * 4, 10);
+        this.file.writeInt32LE(40, 14);
+        this.file.writeInt32LE(width, 18);
+        this.file.writeInt32LE(-height, 22);
+        this.file.writeInt16LE(1, 26);
+        this.file.writeInt16LE(bitDepth, 28);
+        this.file.writeInt32LE(colorAmt, 46);
+        this.fileHeader = new BMP_FileHeader(this.file);
+        this.imageHeader = new BMP_ImageHeader(this.file);
+        this.colorTable = this.file.slice(54, (colorTableSize * 4) + 54);
+        this.pixelData = this.file.slice(this.fileHeader.pixelDataOffset);
+    }
+
+    fileHeader: BMP_FileHeader;
+    imageHeader: BMP_ImageHeader;
+    colorTable: Buffer;
+    pixelData: Buffer;
+
+}
+
+class BMP_FileHeader {
+    private file: Buffer
+
+    constructor(file: Buffer) {
+        this.file = file;
+    }
+
+    get type(): string {
+        return this.file.toString("ascii", 0, 2);
+    }
+
+    get size(): number {
+        return this.file.readInt32LE(2);
+    }
+
+    get pixelDataOffset(): number {
+        return this.file.readInt32LE(10);
+    }
+}
+
+class BMP_ImageHeader {
+    private file: Buffer
+
+    constructor(file: Buffer) {
+        this.file = file;
+    }
+
+    get headerSize(): number {
+        return this.file.readInt32LE(14);
+    }
+
+    get width(): number {
+        return this.file.readInt32LE(18);
+    }
+
+    get height(): number {
+        return this.file.readInt32LE(22);
+    }
+
+    get bpp(): BitDepth {
+        return this.file.readInt16LE(28);
+    }
+
+    get colorAmt(): number {
+        return this.file.readInt32LE(46);
+    }
+}

--- a/src/MajorasMaskOnline/MMOnlineClient.ts
+++ b/src/MajorasMaskOnline/MMOnlineClient.ts
@@ -27,6 +27,7 @@ import { number_ref, string_ref } from 'modloader64_api/Sylvain/ImGui';
 import { flags } from './data/permflags';
 import { Z64OnlineEvents, Z64_PlayerScene } from './Z64OnlineAPI/Z64OnlineAPI';
 import { WorldEvents } from './WorldEvents/WorldEvents';
+import { BitDepth, BMP_Image } from './Bitmap';
 
 export let TIME_SYNC_TRIGGERED: boolean = false;
 
@@ -931,6 +932,38 @@ export class MMOnlineClient {
         this.core.save.minimap_flags = this.clientStorage.minimapStorage;
     }
 
+    bitmapFromPictograph() {
+        let bitmap = new BMP_Image(160, 112, BitDepth.BPP_8, 32);
+        for (let i = 0; i < 32; i++) {
+            let colors = Buffer.alloc(4);
+            colors[1] = Math.round(i * 250 / 31);
+            colors[2] = Math.round(i * 160 / 31);
+            colors[3] = Math.round(i * 160 / 31);
+            bitmap.colorTable.writeUInt32LE(colors.readUInt32BE(0), i * 4)
+        }
+        for (let i = 0; i < 160 * 112; i++) {
+            let bits = (() => {
+                return {
+                    byte: Math.floor(i * 5 / 8),
+                    bitOffset: (i * 5) % 8
+                }
+            })();
+            let pixel: number;
+            let pictograph = this.core.save.photo.pictograph_photoChunk;
+            try {
+                pixel = ((pictograph.readUInt16BE(bits.byte) & (31 << (16 - bits.bitOffset - 5))) >> (16 - bits.bitOffset - 5));
+            } catch {
+                pixel = ((pictograph.readUInt8(bits.byte) & (31 << (8 - bits.bitOffset - 5))) >> (8 - bits.bitOffset - 5));
+            }
+            bitmap.pixelData.writeUInt8(pixel, i);
+        }
+        let filename = `pictograph_${Date.now().toString()}.bmp`;
+        fs.writeFile(path.resolve("./screenshots", filename), bitmap.file, (err) => {
+            if (err) this.ModLoader.logger.error(`${err}`);
+            this.ModLoader.logger.info(`Saved file to ./screenshots/${filename}`);
+        });
+    }
+
     @onViUpdate()
     onVi() {
         if (!this.resourcesLoaded) {
@@ -972,6 +1005,11 @@ export class MMOnlineClient {
                             }
                             this.ModLoader.ImGui.endMenu();
                         }
+                    }
+                    if (this.ModLoader.ImGui.menuItem("Save Pictograph", undefined, undefined, this.core.save.photo.pictograph_used)) {
+                        this.ModLoader.utils.setTimeoutFrames(() => {
+                            this.bitmapFromPictograph();
+                        }, 0);
                     }
                     this.ModLoader.ImGui.endMenu();
                 }


### PR DESCRIPTION
Added "Save Pictograph" option to the MMO menu. Only enabled when a pictograph is in the pictograph box. Saves to `ModLoader/screenshots` as `pictograph_{Date.now()}.bmp`. Potential cleanup to `Bitmap.ts` (will do if so requested). Synced and/or taken pictographs could automatically be saved (opt-in? Exports cause a noticeable freeze) if desired.

[Built pak for testing before merge](https://cdn.discordapp.com/attachments/564536016325574667/807170400186138644/MajorasMaskOnline.pak)

